### PR TITLE
Fix write form for complex input names

### DIFF
--- a/src/persisto.js
+++ b/src/persisto.js
@@ -520,9 +520,11 @@
     /** Write data to form elements with the same name.
      */
     writeToForm: function(form, options) {
-      var $form = $(form);
+      var $form = $(form)
+          self = this;
 
-      $.each(this._data, function(k, v) {
+      $.each(this._data, function(k) {
+        var v = self.get(k);
         var $input = $form.find("[name='" + k + "']"),
           type = $input.attr("type");
 

--- a/src/persisto.js
+++ b/src/persisto.js
@@ -520,8 +520,8 @@
     /** Write data to form elements with the same name.
      */
     writeToForm: function(form, options) {
-      var $form = $(form)
-          self = this;
+      var $form = $(form);
+      self = this;
 
       $.each(this._data, function(k) {
         var v = self.get(k);

--- a/src/persisto.js
+++ b/src/persisto.js
@@ -520,12 +520,12 @@
     /** Write data to form elements with the same name.
      */
     writeToForm: function(form, options) {
-      var $form = $(form);
-      self = this;
+      var $form = $(form),
+        self = this;
 
       $.each(this._data, function(k) {
-        var v = self.get(k);
-        var $input = $form.find("[name='" + k + "']"),
+        var v = self.get(k),
+          $input = $form.find("[name='" + k + "']"),
           type = $input.attr("type");
 
         if ($input.length) {


### PR DESCRIPTION
I've found that this class doesn't restore form values in input fields with complex names.

For instance, given something like:
```html
<input type="text" name="form[person][name]">
``` 
trying to execute 
```javascript
store.writeToForm($form)
```
doesn't work because that function reads from the property `_data` directly. 
This is a quick fix by using the getter `.get(property)`.

Haven't investigated if this affect other situations though.